### PR TITLE
ユーザー詳細ページ追加　#31

### DIFF
--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -35,3 +35,7 @@
 .pagination {
   justify-content: center;
 }
+
+.user-name {
+  font-size: 20px;
+}

--- a/app/assets/stylesheets/profile.scss
+++ b/app/assets/stylesheets/profile.scss
@@ -4,6 +4,12 @@
   height: 150px;
 }
 
+.avatar-mini {
+  border-radius: 50%;
+  width: 70px;
+  height: 70px;
+}
+
 .profile-title {
   line-height: 2.0;
   background-color: black;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -10,6 +10,7 @@ class EventsController < ApplicationController
 
   def show
     @event = Event.find(params[:id])
+    @user = @event.user
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
 
   def show
-    @user = User.find_by(id: params[:id])
+    @user = User.find(params[:id])
   end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,8 @@ class User < ApplicationRecord
   has_many :events, dependent: :destroy
   has_one :profile, dependent: :destroy
 
+  delegate :gender, :introduction, :age_cal, to: :profile, allow_nil: true
+
   #パスワードなしで変更可能
   def update_without_current_password(params, *options)
     if params[:password].blank? && params[:password_confirmation].blank?

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -1,0 +1,32 @@
+.card 
+  .card-body
+    .row
+      .profile-image.col-3
+        = image_tag current_user.avatar_image, class:'avatar'
+      .profile-text.col-9
+        .profile-name
+          = current_user.display_name
+        %hr 
+        %dl.gender 
+          .row 
+            %dt.col-2 性別
+            %dd.col-8
+              - if current_user.profile&.gender.present?
+                = I18n.t("enum.genders.#{current_user.profile.gender}")
+        %hr 
+        %dl.age 
+          .row 
+            %dt.col-2 年齢
+            %dd.col-8
+              = current_user.profile&.age_cal
+        %hr
+        %dl.introduction
+          .row
+            %dt.col-2 自己紹介
+            %dd.col-8
+              = current_user.profile&.introduction
+.user-event.mt-5
+  .text-title.mb-4 投稿イベント一覧
+  - current_user.events.each do |event|
+    = render 'commons/event', event: event
+

--- a/app/views/commons/_profile.html.haml
+++ b/app/views/commons/_profile.html.haml
@@ -6,25 +6,28 @@
       .profile-text.col-9
         .profile-name
           = current_user.display_name
-        %hr 
-        %dl.gender 
-          .row 
-            %dt.col-2 性別
-            %dd.col-8
-              - if current_user.profile&.gender.present?
-                = I18n.t("enum.genders.#{current_user.profile.gender}")
-        %hr 
-        %dl.age 
-          .row 
-            %dt.col-2 年齢
-            %dd.col-8
-              = current_user.profile&.age_cal
-        %hr
-        %dl.introduction
-          .row
-            %dt.col-2 自己紹介
-            %dd.col-8
-              = current_user.profile&.introduction
+        - if current_user.gender.present?
+          %hr
+          %dl.gender 
+            .row 
+              %dt.col-2 性別
+              %dd.col-8
+                - if current_user.gender.present?
+                  = I18n.t("enum.genders.#{current_user.profile.gender}")
+        - if current_user.age_cal.present?
+          %hr 
+          %dl.age 
+            .row 
+              %dt.col-2 年齢
+              %dd.col-8
+                = current_user.age_cal
+        - if current_user.introduction.present?
+          %hr
+          %dl.introduction
+            .row
+              %dt.col-2 自己紹介
+              %dd.col-8
+                = current_user.introduction
 .user-event.mt-5
   .text-title.mb-4 投稿イベント一覧
   - current_user.events.each do |event|

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -30,6 +30,14 @@
           .second-title 開催店舗
           .event-store 
             = @event.store
+          %hr
+          .second-title.mb-3 作成者
+          = link_to user_path(@user) do
+            .row
+              .user-avator.col-5
+                = image_tag @event.user.avatar_image, class: 'avatar-mini'
+              .user-name.col-6.d-flex.align-items-center
+                = @event.user.display_name
       - if user_signed_in? && current_user.has_written?(@event)
         .option
           = link_to 'イベント編集', edit_event_path(@event), class: 'btn btn-success edit-button'

--- a/app/views/profiles/show.html.haml
+++ b/app/views/profiles/show.html.haml
@@ -1,37 +1,6 @@
 .container 
   .row
     .left-content.col-9.mt-5 
-      .card 
-        .card-body
-          .row
-            .profile-image.col-3
-              = image_tag current_user.avatar_image, class:'avatar'
-            .profile-text.col-9
-              .profile-name
-                = current_user.display_name
-              %hr 
-              %dl.gender 
-                .row 
-                  %dt.col-2 性別
-                  %dd.col-8
-                    - if current_user.profile&.gender.present?
-                      = I18n.t("enum.genders.#{current_user.profile.gender}")
-              %hr 
-              %dl.age 
-                .row 
-                  %dt.col-2 年齢
-                  %dd.col-8
-                    = current_user.profile&.age_cal
-              %hr
-              %dl.introduction
-                .row
-                  %dt.col-2 自己紹介
-                  %dd.col-8
-                    = current_user.profile&.introduction
-      .user-event.mt-5
-        .text-title.mb-4 投稿イベント一覧
-        - current_user.events.each do |event|
-          = render 'commons/event', event: event
-
+      = render 'commons/profile'
     .right-content.col-3.mt-5 
       = render 'commons/link' 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,1 +1,4 @@
-ユーザー詳細ページ
+.container 
+  .row
+    .left-content.col-9.mt-5 
+      = render 'commons/profile', current_user: @user


### PR DESCRIPTION
close #31 
- ユーザー詳細ページの作成
- ユーザー詳細ページへのリンクイベント詳細ページに追加
- ユーザー詳細ページのカード部分をテンプレート化
- プロフィール情報の表示方法変更