### PR TITLE
イベント自動close機能 #47

### DIFF
--- a/app/assets/stylesheets/event.scss
+++ b/app/assets/stylesheets/event.scss
@@ -7,6 +7,17 @@
   object-fit: cover;
 }
 
+.status {
+  background-color:  #999;
+  color: white;
+}
+
+.close-button {
+  cursor: not-allowed;
+  pointer-events: none;
+}
+
+
 .preview-image {
   width: 40%;
   height: auto;

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -89,7 +89,7 @@ class EventsController < ApplicationController
   private
 
   def event_params
-    params.require(:event).permit(:name, :text, :store, :address, :start_time, :eyecatch, :prefecture_id, :category_id)
+    params.require(:event).permit(:name, :text, :store, :address, :start_time, :eyecatch, :category_id)
   end
 
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -20,6 +20,14 @@ module EventDecorator
     end
   end
 
+  def category_name
+    if self.category.present?
+      self.category.name
+    else
+      I18n.t('events.show.unspecified')
+    end
+  end
+
 
 
   def eyecatch_image

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,18 +2,18 @@
 #
 # Table name: events
 #
-#  id            :bigint           not null, primary key
-#  address       :string
-#  latitude      :float
-#  longitude     :float
-#  name          :string           not null
-#  start_time    :date
-#  store         :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  category_id   :integer
-#  prefecture_id :integer
-#  user_id       :bigint           not null
+#  id          :bigint           not null, primary key
+#  address     :string
+#  latitude    :float
+#  longitude   :float
+#  name        :string           not null
+#  start_time  :date
+#  status      :boolean          default(FALSE)
+#  store       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :integer
+#  user_id     :bigint           not null
 #
 # Indexes
 #
@@ -39,6 +39,11 @@ class Event < ApplicationRecord
 
   validates :name, presence: true
   validates :text, presence: true
+  validate :day_after_today
+
+  def day_after_today
+      errors.add(:base, "開催日程は今日より前の日は指定できません") if start_time < Date.today
+  end
 
   #タグ作成
   def save_event_tag(tags)

--- a/app/views/calendars/index.html.haml
+++ b/app/views/calendars/index.html.haml
@@ -7,4 +7,7 @@
     = date.day
     - events.each do |event|
       .calendar-link-box
-        = link_to ("・#{event.name}"), event_path(event), class: 'calendar-link'
+        - if event.status?
+          = link_to ("・#{event.name}(終)"), event_path(event), class: 'calendar-link'
+        - else
+          = link_to ("・#{event.name}"), event_path(event), class: 'calendar-link'

--- a/app/views/commons/_event.html.haml
+++ b/app/views/commons/_event.html.haml
@@ -8,7 +8,10 @@
           .event-title 
             = event.name
           .event-date.mb-4.text-muted
-            = event.display_date
+            - if event.status?
+              %span.border.p-1.status 終了しました
+            - else
+              = event.display_date
           - if event.tags.present?
             %object
               - event.tags.each do |list|

--- a/app/views/events/index.html.haml
+++ b/app/views/events/index.html.haml
@@ -12,4 +12,3 @@
                 = event.name
               %p.card-text 
                 = event.text
-                = event.category.name

--- a/app/views/events/show.html.haml
+++ b/app/views/events/show.html.haml
@@ -26,8 +26,11 @@
               = link_to I18n.t('events.show.edit'), edit_event_path(@event), class: 'btn btn-success edit-button'
               = link_to I18n.t('events.show.delete'), event_path(@event), data: { method: 'delete', confirm: '本当に削除してよろしいですか？' }, class: 'btn btn-danger'
           - else
-            .btn.btn-primary.btn-lg.join-button.hidden.active-join= I18n.t('events.show.join-now')
-            .btn.btn-outline-primary.btn-lg.join-button.hidden.inactive-join= I18n.t('events.show.join')
+            - if @event.status?
+              .btn.btn-danger.btn-lg.join-button.close-button 終了
+            - else
+              .btn.btn-primary.btn-lg.join-button.hidden.active-join= I18n.t('events.show.join-now')
+              .btn.btn-outline-primary.btn-lg.join-button.hidden.inactive-join= I18n.t('events.show.join')
       .btn.btn-outline-success.show-comment-form
         = I18n.t('events.show.add-comment')
       .comment-container.hidden
@@ -67,7 +70,7 @@
           %hr
           .second-title= I18n.t('events.show.category')
           .event-store 
-            = @event.category.name
+            = @event.category_name
           %hr
           - if @event.address.present?
             .second-title= I18n.t('events.show.address')

--- a/config/locales/events.en.yml
+++ b/config/locales/events.en.yml
@@ -54,3 +54,4 @@ en:
       address: "Address"
       contributor: "Contributor"
       undecided: "Undecided"
+      unspecified: "unspecified"

--- a/config/locales/events.ja.yml
+++ b/config/locales/events.ja.yml
@@ -54,3 +54,4 @@ ja:
       address: "開催店舗住所"
       contributor: "作成者"
       undecided: "未定"
+      unspecified: "指定なし"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,6 +10,7 @@ ja:
       event:
         name: "イベント名"
         text: "イベント内容"
+        start_time: "開催日程"
       profile:
         name: "ユーザー名"
   date:

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,3 +11,7 @@ set :output, "#{Rails.root}/log/cron.log"
 every 1.day, at: '8am' do
   rake 'admin_report:mail_admin_report'
 end
+
+every 1.day, at: '8am' do
+  rake 'close_event:close_event'
+end

--- a/db/migrate/20210705024555_add_status_to_events.rb
+++ b/db/migrate/20210705024555_add_status_to_events.rb
@@ -1,0 +1,5 @@
+class AddStatusToEvents < ActiveRecord::Migration[6.1]
+  def change
+    add_column :events, :status, :boolean,  default: false
+  end
+end

--- a/db/migrate/20210705092237_remove_prefecture_id_to_events.rb
+++ b/db/migrate/20210705092237_remove_prefecture_id_to_events.rb
@@ -1,0 +1,5 @@
+class RemovePrefectureIdToEvents < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :events, :prefecture_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_25_043921) do
+ActiveRecord::Schema.define(version: 2021_07_05_092237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,13 +86,13 @@ ActiveRecord::Schema.define(version: 2021_06_25_043921) do
     t.string "name", null: false
     t.string "store"
     t.date "start_time"
-    t.integer "prefecture_id"
     t.integer "category_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "address"
     t.float "latitude"
     t.float "longitude"
+    t.boolean "status", default: false
     t.index ["user_id"], name: "index_events_on_user_id"
   end
 

--- a/lib/tasks/close_event.rake
+++ b/lib/tasks/close_event.rake
@@ -1,0 +1,6 @@
+namespace :close_event do
+  desc "イベント開催日が過ぎたらイベントをcloseする"
+  task close_event: :environment do
+    Event.where('start_time < ?', Date.today).where(status: false).update(status: true)
+  end
+end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -2,18 +2,18 @@
 #
 # Table name: events
 #
-#  id            :bigint           not null, primary key
-#  address       :string
-#  latitude      :float
-#  longitude     :float
-#  name          :string           not null
-#  start_time    :date
-#  store         :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  category_id   :integer
-#  prefecture_id :integer
-#  user_id       :bigint           not null
+#  id          :bigint           not null, primary key
+#  address     :string
+#  latitude    :float
+#  longitude   :float
+#  name        :string           not null
+#  start_time  :date
+#  status      :boolean          default(FALSE)
+#  store       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :integer
+#  user_id     :bigint           not null
 #
 # Indexes
 #

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -2,18 +2,18 @@
 #
 # Table name: events
 #
-#  id            :bigint           not null, primary key
-#  address       :string
-#  latitude      :float
-#  longitude     :float
-#  name          :string           not null
-#  start_time    :date
-#  store         :string
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  category_id   :integer
-#  prefecture_id :integer
-#  user_id       :bigint           not null
+#  id          :bigint           not null, primary key
+#  address     :string
+#  latitude    :float
+#  longitude   :float
+#  name        :string           not null
+#  start_time  :date
+#  status      :boolean          default(FALSE)
+#  store       :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  category_id :integer
+#  user_id     :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
close #47 
- イベントにstatusカラムを追加 
- 使用していないprefecture_idカラムを削除
- イベントstatusによってイベントの表示を切り替え
- イベントclose機能をタスクに追加
- イベントclose機能を定期実行
- イベント開催日が今日より前の日にならないようにvalidationを指定
- イベント詳細のカテゴリー部分のメソッド化と多言語化