### PR TITLE
イベント取得制限追加 #120

### DIFF
--- a/app/controllers/calendars_controller.rb
+++ b/app/controllers/calendars_controller.rb
@@ -1,5 +1,6 @@
 class CalendarsController < ApplicationController
+  EVENT_LIMIT = 100
   def index
-    @events = Event.all
+    @events = Event.limit(EVENT_LIMIT)
   end
 end

--- a/app/controllers/clip_events_controller.rb
+++ b/app/controllers/clip_events_controller.rb
@@ -1,7 +1,8 @@
 class ClipEventsController < ApplicationController
   before_action :authenticate_user!
+  PER_PAGE = 5
 
   def index
-    @events = current_user.clip_events.includes(:tags, :tagmaps).with_attached_eyecatch
+    @events = current_user.clip_events.includes(:tags, :tagmaps).with_attached_eyecatch.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/controllers/join_events_controller.rb
+++ b/app/controllers/join_events_controller.rb
@@ -1,7 +1,8 @@
 class JoinEventsController < ApplicationController
   before_action :authenticate_user!
+  PER_PAGE = 5
 
   def index
-    @events = current_user.join_events.includes(:tags, :tagmaps).with_attached_eyecatch
+    @events = current_user.join_events.includes(:tags, :tagmaps).with_attached_eyecatch.page(params[:page]).per(PER_PAGE)
   end
 end

--- a/app/views/clip_events/index.html.haml
+++ b/app/views/clip_events/index.html.haml
@@ -4,3 +4,6 @@
   .profile-title.mt-5
     %h4= I18n.t('profiles.clip-event')
   = render 'commons/events', events: @events
+  - if @events.present?
+    .page.mt-3
+      = paginate @events,theme: 'twitter-bootstrap-4'

--- a/app/views/join_events/index.html.haml
+++ b/app/views/join_events/index.html.haml
@@ -4,3 +4,6 @@
   .profile-title.mt-5
     %h4= I18n.t('profiles.join-event')
   = render 'commons/events', events: @events
+  - if @events.present?
+    .page.mt-3
+      = paginate @events,theme: 'twitter-bootstrap-4'


### PR DESCRIPTION
close #120 

- カレンダーページで取得できるイベントを制限
- マイページでクリップしたイベントの取得制限、ページネーションの追加
- マイページで参加したイベントの取得制限、ページネーションの追加